### PR TITLE
Fix error handler crash on missing Accept header

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -44,7 +44,7 @@ container.registerInstance('Logger', log);
 export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
     log.error('Unknown error', err);
     const status = err.status || 500;
-    const errorPageFormatHint = req.header('accept');
+    const errorPageFormatHint = req.header('accept') || '';
 
     if (res.headersSent) {
         return;


### PR DESCRIPTION
## Summary
- prevent crash when `Accept` header is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fda52eac0832d97a387297990efb5